### PR TITLE
Be compatible with Lua 5.3

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -56,8 +56,6 @@ local __meta = {
 s:set_fallback('en')
 s:set_namespace('en')
 
-if _TEST then
-  s._registry = registry -- force different name to make sure with _TEST behaves exactly as without _TEST
-end
+s._registry = registry
 
 return setmetatable(s, __meta)

--- a/src/init.lua
+++ b/src/init.lua
@@ -1,3 +1,5 @@
+local unpack = table.unpack or unpack
+
 local registry = { }
 local current_namespace
 local fallback_namespace


### PR DESCRIPTION
In Lua 5.2 unpack was deprecated and replaced with table.unpack, in Lua 5.3 unpack is removed.